### PR TITLE
Fix story mutation validation

### DIFF
--- a/src/mutations/story.js
+++ b/src/mutations/story.js
@@ -62,7 +62,7 @@ function validate(input, { t, user }) {
   }
 
   if (typeof input.text !== 'undefined' && input.text.trim() !== '') {
-    if (!validator.isLength(input.url, { min: 20, max: 2000 })) {
+    if (!validator.isLength(input.text, { min: 20, max: 2000 })) {
       errors.push({ key: 'text', message: t('The text field must be between 20 and 2000 characters long.') });
     } else {
       data.text = input.text;


### PR DESCRIPTION
The length validator for the `text` field was looking at `input.url` instead of `input.text`. This updates the validator to use the appropriate field.