### PR TITLE
Update .eslintrc.js

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,6 +21,6 @@ module.exports = {
         trailingComma: 'all',
       },
     ],
-    'flowtype/define-flow-type': 1
+    'flowtype/define-flow-type': 1,
   },
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,5 +21,6 @@ module.exports = {
         trailingComma: 'all',
       },
     ],
+    'flowtype/define-flow-type': 1
   },
 };


### PR DESCRIPTION
add `flowtype/define-flow-type` rule to support 

```
// @flow
const countries = {
  US: "United States",
  IT: "Italy",
  FR: "France"
};

type Country = $Keys<typeof countries>;
```