### PR TITLE
fix: parent comment might not exist

### DIFF
--- a/src/schema/CommentType.js
+++ b/src/schema/CommentType.js
@@ -37,9 +37,9 @@ const CommentType = new GraphQLObjectType({
     },
 
     parent: {
-      type: new GraphQLNonNull(CommentType),
+      type: CommentType,
       resolve(parent, args, { commentById }) {
-        return commentById.load(parent.parent_id);
+        return parent.parent_id && commentById.load(parent.parent_id);
       },
     },
 


### PR DESCRIPTION
Demo graphiql returns the error based on seed data.

```javascript
{
      "message": "Cannot read property 'load' of undefined",
      "locations": [
        {
          "line": 14,
          "column": 9
        }
      ],
      "path": [
        "stories",
        "edges",
        0,
        "node",
        "comments"
      ]
    }
```
I think comment could have no parent if it's a parent comment.