### PR TITLE
Replace users.emails JSONB field with emails table

### DIFF
--- a/migrations/201612010000_initial.js
+++ b/migrations/201612010000_initial.js
@@ -9,6 +9,7 @@
 
 // Create database schema for storing user accounts, logins and authentication claims/tokens
 // Source https://github.com/membership/membership.db
+// prettier-ignore
 module.exports.up = async db => {
   // User accounts
   await db.schema.createTable('users', table => {
@@ -18,8 +19,18 @@ module.exports.up = async db => {
     table.uuid('id').notNullable().defaultTo(db.raw('uuid_generate_v1mc()')).primary();
     table.string('display_name', 100);
     table.string('image_url', 200);
-    table.jsonb('emails').notNullable().defaultTo('[]');
     table.timestamps(false, true);
+  });
+
+  // Users' email addresses
+  await db.schema.createTable('emails', table => {
+    table.uuid('id').notNullable().defaultTo(db.raw('uuid_generate_v1mc()')).primary();
+    table.uuid('user_id').notNullable().references('id').inTable('users').onDelete('CASCADE').onUpdate('CASCADE');
+    table.string('email', 100);
+    table.boolean('verified').notNullable().defaultTo(false);
+    table.boolean('primary').notNullable().defaultTo(false);
+    table.timestamps(false, true);
+    table.unique(['user_id', 'email', 'verified']);
   });
 
   // External logins with security tokens (e.g. Google, Facebook, Twitter)
@@ -71,6 +82,7 @@ module.exports.down = async db => {
   await db.schema.dropTableIfExists('story_points');
   await db.schema.dropTableIfExists('stories');
   await db.schema.dropTableIfExists('logins');
+  await db.schmea.dropTableIfExists('emails');
   await db.schema.dropTableIfExists('users');
 };
 

--- a/migrations/201612010000_initial.js
+++ b/migrations/201612010000_initial.js
@@ -26,7 +26,7 @@ module.exports.up = async db => {
   await db.schema.createTable('emails', table => {
     table.uuid('id').notNullable().defaultTo(db.raw('uuid_generate_v1mc()')).primary();
     table.uuid('user_id').notNullable().references('id').inTable('users').onDelete('CASCADE').onUpdate('CASCADE');
-    table.string('email', 100);
+    table.string('email', 100).notNullable();
     table.boolean('verified').notNullable().defaultTo(false);
     table.boolean('primary').notNullable().defaultTo(false);
     table.timestamps(false, true);

--- a/src/Context.js
+++ b/src/Context.js
@@ -45,6 +45,22 @@ class Context {
       .then(mapTo(keys, x => x.id, 'User')),
   );
 
+  emailById = new DataLoader(keys =>
+    db
+      .table('emails')
+      .whereIn('id', keys)
+      .select()
+      .then(mapTo(keys, x => x.id, 'Email')),
+  );
+
+  emailsByUserId = new DataLoader(keys =>
+    db
+      .table('emails')
+      .whereIn('user_id', keys)
+      .select()
+      .then(mapToMany(keys, x => x.user_id, 'Email')),
+  );
+
   storyById = new DataLoader(keys =>
     db
       .table('stories')

--- a/src/schema/EmailType.js
+++ b/src/schema/EmailType.js
@@ -15,19 +15,26 @@ import {
   GraphQLString,
   GraphQLBoolean,
 } from 'graphql';
+import { globalIdField } from 'graphql-relay';
+import { nodeInterface } from './Node';
 
 export default new GraphQLObjectType({
   name: 'Email',
+  interfaces: [nodeInterface],
+
   fields: {
+    id: globalIdField(),
+
     email: {
       type: new GraphQLNonNull(GraphQLString),
     },
 
     verified: {
       type: new GraphQLNonNull(GraphQLBoolean),
-      resolve(parent) {
-        return !!parent.verified;
-      },
+    },
+
+    primary: {
+      type: new GraphQLNonNull(GraphQLBoolean),
     },
   },
 });

--- a/src/schema/Node.js
+++ b/src/schema/Node.js
@@ -17,6 +17,7 @@ const { nodeInterface, nodeField: node, nodesField: nodes } = nodeDefinitions(
     const { type, id } = fromGlobalId(globalId);
 
     if (type === 'User') return context.userById.load(id);
+    if (type === 'Email') return context.emailById.load(id);
     if (type === 'Story') return context.storyById.load(id);
     if (type === 'Comment') return context.commentById.load(id);
 
@@ -24,6 +25,7 @@ const { nodeInterface, nodeField: node, nodesField: nodes } = nodeDefinitions(
   },
   obj => {
     if (obj.__type === 'User') return require('./UserType').default;
+    if (obj.__type === 'Email') return require('./EmailType').default;
     if (obj.__type === 'Story') return require('./StoryType').default;
     if (obj.__type === 'Comment') return require('./CommentType').default;
 

--- a/src/schema/UserType.js
+++ b/src/schema/UserType.js
@@ -38,8 +38,8 @@ export default new GraphQLObjectType({
 
     emails: {
       type: new GraphQLList(EmailType),
-      resolve(parent, args, { user }) {
-        return user && parent.id === user.id ? parent.emails : null;
+      resolve(user, args, { emailsByUserId }) {
+        return emailsByUserId.load(user.id);
       },
     },
   },


### PR DESCRIPTION
The `users.emails` JSONB field is now deprecated in favor of a separate table for storing users' email addresses:

```js
  await db.schema.createTable('emails', table => {
    table.uuid('id').notNullable().defaultTo(db.raw('uuid_generate_v1mc()')).primary();
    table.uuid('user_id').notNullable().references('id').inTable('users').onDelete('CASCADE').onUpdate('CASCADE');
    table.string('email', 100).notNullable();
    table.boolean('verified').notNullable().defaultTo(false);
    table.boolean('primary').notNullable().defaultTo(false);
    table.timestamps(false, true);
    table.unique(['user_id', 'email', 'verified']);
  });
```