### PR TITLE
Add additional docs to the publish script

### DIFF
--- a/tools/publish.js
+++ b/tools/publish.js
@@ -11,7 +11,13 @@
 const cp = require('child_process');
 const pkg = require('../package.json');
 
+// URI of the remote host that will be serving the API server.
 const host = process.argv[2];
+
+// This is your production docker-compose file.
+// This file must be present on the server hosting the production application.
+// You must ensure this file is present on the server in advance of running
+// the publish script.
 const composeFile = '/usr/src/app/docker-compose.yml';
 
 if (!host) {
@@ -27,6 +33,7 @@ Options:
   process.exit();
 }
 
+// Build the API server locally.
 cp.spawnSync(
   'docker-compose',
   [
@@ -40,9 +47,15 @@ cp.spawnSync(
   ],
   { stdio: 'inherit' },
 );
+
+// Create a Docker image based on the pre-built API server.
+// This step speeds the update process and ensures the remote server
+// doesn't hang while you update it.
 cp.spawnSync('docker', ['build', '--no-cache', '--tag', pkg.name, '.'], {
   stdio: 'inherit',
 });
+
+// Pipe the container data to the remote host.
 const ssh = cp.spawn('ssh', ['-C', host, 'docker', 'load'], {
   stdio: ['pipe', 'inherit', 'inherit'],
 });
@@ -54,12 +67,19 @@ docker.on('exit', () => {
 });
 ssh.on('exit', () => {
   if (process.argv.includes('--no-up')) return;
+
+  // Using the production docker-compose configuration file (must be present
+  // on the remote server already), start the API server and any dependencies
+  // in the background (via -d).
   cp.spawnSync(
     'ssh',
     ['-C', host, 'docker-compose', '-f', composeFile, 'up', '-d'],
     { stdio: 'inherit' },
   );
+
   if (process.argv.includes('--no-prune')) return;
+
+  // Prune any old images from the remove server.
   cp.spawnSync('ssh', ['-C', host, 'docker', 'image', 'prune', '-a', '-f'], {
     stdio: 'inherit',
   });


### PR DESCRIPTION
A number of issues have arisen regarding how `tools/publish.js` works and what its prerequisites are.

This PR adds additional documentation to `publish.js` explaining what each docker command does and what prerequisites are needed.