### PR TITLE
Force select email (Google Login)

### DIFF
--- a/src/routes/account.js
+++ b/src/routes/account.js
@@ -81,7 +81,11 @@ loginProviders.forEach(({ provider, options }) => {
       req.session.returnTo = getSuccessRedirect(req);
       next();
     },
-    passport.authenticate(provider, { failureFlash: true, ...options }),
+    passport.authenticate(provider, {
+      failureFlash: true,
+      prompt: 'select_account',
+      ...options,
+    }),
   );
 
   router.get(`/login/${provider}/return`, (req, res, next) =>


### PR DESCRIPTION
I found there were times that when you logout using Google login and tried logging back in that it would automatically log you in.  As an average user of an application I would think its likely they would use apps with multiple emails.  

My assumption is a average user would not be able to figure out how clear cache/cookies, get frustrated and possibly leave.

There may be a better way to do this as I am not sure it works with other login systems (twitter/facebook)

Where I had found the fix:
https://github.com/google/google-api-nodejs-client/issues/899