### PR TITLE
Define global scripts per workspace

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -6,11 +6,17 @@
   "main": "lib/index.js",
   "scripts": {
     "start": "nodemon ./src",
-    "start:debug": "nodemon --inspect ./src",
+    "start-debug": "nodemon --inspect ./src",
     "test": "jest",
     "build": "babel ./src -x .ts --out-dir lib --delete-dir-on-start --verbose",
     "update-schema": "babel-node -x .ts ./scripts/update-schema",
-    "update-types": "babel-node -x .ts ./scripts/update-types"
+    "update-types": "babel-node -x .ts ./scripts/update-types",
+    "api:start": "yarn workspace api start",
+    "api:start-debug": "yarn workspace api start-debug",
+    "api:test": "yarn workspace api test",
+    "api:build": "yarn workspace api build",
+    "api:update-schema": "yarn workspace api update-schema",
+    "api:update-types": "yarn workspace api update-types"
   },
   "dependencies": {
     "@sendgrid/mail": "^7.2.2",

--- a/api/schema.graphql
+++ b/api/schema.graphql
@@ -124,6 +124,12 @@ type Comment implements Node {
 }
 
 type Mutation {
+  # Authenticates user with a Firebase ID token.
+  signIn(idToken: String!): SignInPayload
+
+  # Removes the authentication cookie.
+  signOut: String
+
   # Updates a user.
   updateUser(input: UpdateUserInput!): UpdateUserPayload
 
@@ -135,6 +141,10 @@ type Mutation {
 
   # Marks the story as "liked".
   likeStory(input: LikeStoryInput!): LikeStoryPayload
+}
+
+type SignInPayload {
+  me: User
 }
 
 type UpdateUserPayload {

--- a/db/package.json
+++ b/db/package.json
@@ -13,7 +13,17 @@
     "backup": "node ./scripts/backup",
     "restore": "node ./scripts/restore",
     "repl": "node --experimental-repl-await ./scripts/repl",
-    "psql": "node ./scripts/psql"
+    "psql": "node ./scripts/psql",
+    "db:version": "yarn workspace db version",
+    "db:change": "yarn workspace db change",
+    "db:migrate": "yarn workspace db migrate",
+    "db:rollback": "yarn workspace db rollback",
+    "db:seed": "yarn workspace db seed",
+    "db:reset": "yarn workspace db reset",
+    "db:backup": "yarn workspace db backup",
+    "db:restore": "yarn workspace db restore",
+    "db:repl": "yarn workspace db repl",
+    "db:psql": "yarn workspace db psql"
   },
   "devDependencies": {
     "env": "workspace:*",

--- a/package.json
+++ b/package.json
@@ -11,21 +11,7 @@
   "scripts": {
     "start": "yarn workspaces foreach -ip run start",
     "g:lint": "cd $INIT_CWD && eslint --cache",
-    "g:format": "CONFIG=\"$(pwd)/package.json\" IGNORE=\"$(pwd)/.prettierignore\" && cd $INIT_CWD && prettier --config \"$CONFIG\" --ignore-path \"$IGNORE\"",
-    "db:version": "yarn workspace db version",
-    "db:change": "yarn workspace db change",
-    "db:migrate": "yarn workspace db migrate",
-    "db:rollback": "yarn workspace db rollback",
-    "db:seed": "yarn workspace db seed",
-    "db:reset": "yarn workspace db reset",
-    "db:backup": "yarn workspace db backup",
-    "db:restore": "yarn workspace db restore",
-    "db:repl": "yarn workspace db repl",
-    "db:psql": "yarn workspace db psql",
-    "api:start": "yarn workspace api start",
-    "api:build": "yarn workspace api build",
-    "api:update-schema": "yarn workspace api update-schema",
-    "api:update-types": "yarn workspace api update-types"
+    "g:format": "CONFIG=\"$(pwd)/package.json\" IGNORE=\"$(pwd)/.prettierignore\" && cd $INIT_CWD && prettier --config \"$CONFIG\" --ignore-path \"$IGNORE\""
   },
   "dependencies": {
     "@babel/cli": "^7.10.5",


### PR DESCRIPTION
Move workspace related global scripts from the top-level `package.json` into `package.json` inside of workspaces.