### PR TITLE
Replace child_process.spawn with cross-spawn

### DIFF
--- a/.pnp.js
+++ b/.pnp.js
@@ -5129,6 +5129,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageLocation": "./db/",
           "packageDependencies": [
             ["db", "workspace:db"],
+            ["cross-spawn", "npm:7.0.3"],
             ["env", "workspace:env"],
             ["faker", "npm:4.1.0"],
             ["knex", "virtual:0460f86c7587ee75dac643681550c044e8047ba46e219a5baac054fc0fea2d0af97a9bd3fe4b22de0884797215e0a1a4368bb60f9ef7087a69c4008789f4e032#npm:0.21.2"],

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,6 +18,7 @@
     "abcdefghijklmnopqrstuvwxyz",
     "corejs",
     "dataloader",
+    "datname",
     "jsonb",
     "knexfile",
     "pgdatabase",

--- a/api/package.json
+++ b/api/package.json
@@ -20,7 +20,6 @@
   },
   "dependencies": {
     "@sendgrid/mail": "^7.2.3",
-    "@types/node": "^14.0.27",
     "body-parser": "^1.19.0",
     "compression": "^1.7.4",
     "cookie": "^0.4.1",
@@ -63,6 +62,7 @@
     "@types/lodash": "^4.14.159",
     "@types/minimist": "^1.2.0",
     "@types/moment-timezone": "^0.5.13",
+    "@types/node": "^14.0.27",
     "@types/uuid": "^8.0.1",
     "@types/validator": "^13.1.0",
     "@typescript-eslint/eslint-plugin": "^3.8.0",

--- a/db/package.json
+++ b/db/package.json
@@ -26,6 +26,7 @@
     "db:psql": "yarn workspace db psql"
   },
   "devDependencies": {
+    "cross-spawn": "*",
     "env": "workspace:*",
     "faker": "^4.1.0",
     "knex": "^0.21.2",

--- a/db/scripts/backup.js
+++ b/db/scripts/backup.js
@@ -9,6 +9,7 @@
 const fs = require("fs");
 const path = require("path");
 const readline = require("readline");
+const spawn = require("cross-spawn");
 const cp = require("child_process");
 const { EOL } = require("os");
 
@@ -16,7 +17,7 @@ const { EOL } = require("os");
 require("env");
 
 // Get the list of database tables
-let cmd = cp.spawnSync(
+let cmd = spawn.sync(
   "psql",
   [
     "--no-align",

--- a/db/scripts/psql.js
+++ b/db/scripts/psql.js
@@ -7,7 +7,7 @@
  * @copyright 2016-present Kriasoft (https://git.io/vMINh)
  */
 
-const cp = require("child_process");
+const spawn = require("cross-spawn");
 const { _ } = require("minimist")(process.argv.slice(2));
 
 // Load environment variables (PGHOST, PGUSER, etc.)
@@ -15,9 +15,9 @@ require("env");
 
 // Create a new database if it doesn't exist
 const cmd = `CREATE DATABASE "${process.env.PGDATABASE}"`;
-cp.spawnSync("psql", ["-d", "postgres", "-c", cmd], {
+spawn.sync("psql", ["-d", "postgres", "-c", cmd], {
   stdio: "ignore",
 });
 
 // Launch interactive terminal for working with PostgreSQL
-cp.spawn("psql", _, { stdio: "inherit" });
+spawn("psql", _, { stdio: "inherit" });

--- a/db/scripts/reset.js
+++ b/db/scripts/reset.js
@@ -7,7 +7,7 @@
  */
 
 const knex = require("knex");
-const cp = require("child_process");
+const spawn = require("cross-spawn");
 const config = require("../knexfile");
 
 const db = knex({
@@ -16,14 +16,25 @@ const db = knex({
 });
 
 Promise.resolve()
+  // Drop existing connections
+  .then(() =>
+    db.raw(
+      `
+      SELECT pg_terminate_backend(pg_stat_activity.pid)
+      FROM pg_stat_activity
+      WHERE pg_stat_activity.datname = ? AND pid <> pg_backend_pid()`,
+      [process.env.PGDATABASE],
+    ),
+  )
+
   // Drop and re-create the database
-  .then(() => db.raw(`DROP DATABASE IF EXISTS "${process.env.PGDATABASE}"`))
-  .then(() => db.raw(`CREATE DATABASE "${process.env.PGDATABASE}"`))
+  .then(() => db.raw(`DROP DATABASE IF EXISTS ??`, [process.env.PGDATABASE]))
+  .then(() => db.raw(`CREATE DATABASE ??`, [process.env.PGDATABASE]))
   .finally(() => db.destroy())
 
   // Migrate database to the latest version
   .then(() => {
-    cp.spawnSync("yarn", ["knex", "migrate:latest"], { stdio: "inherit" });
-    cp.spawnSync("yarn", ["knex", "seed:run"], { stdio: "inherit" });
-    cp.spawnSync("yarn", ["api:update-types"], { stdio: "inherit" });
+    spawn.sync("yarn", ["knex", "migrate:latest"], { stdio: "inherit" });
+    spawn.sync("yarn", ["knex", "seed:run"], { stdio: "inherit" });
+    spawn.sync("yarn", ["api:update-types"], { stdio: "inherit" });
   });

--- a/db/scripts/restore.js
+++ b/db/scripts/restore.js
@@ -8,7 +8,7 @@
 
 const fs = require("fs");
 const path = require("path");
-const cp = require("child_process");
+const spawn = require("cross-spawn");
 
 // Load environment variables (PGHOST, PGUSER, etc.)
 require("env");
@@ -28,7 +28,7 @@ if (!file) {
 
 console.log(`Restoring ${file} to ${PGDATABASE} (${ENV})...`);
 
-cp.spawn(
+spawn(
   "psql",
   [
     "--file",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4055,7 +4055,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cross-spawn@npm:7.0.3, cross-spawn@npm:^7.0.0, cross-spawn@npm:^7.0.2":
+"cross-spawn@npm:*, cross-spawn@npm:7.0.3, cross-spawn@npm:^7.0.0, cross-spawn@npm:^7.0.2":
   version: 7.0.3
   resolution: "cross-spawn@npm:7.0.3"
   dependencies:
@@ -4182,6 +4182,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "db@workspace:db"
   dependencies:
+    cross-spawn: "*"
     env: "workspace:*"
     faker: ^4.1.0
     knex: ^0.21.2


### PR DESCRIPTION
- Replace [`child_process.spawn`](https://nodejs.org/api/child_process.html#child_process_child_process_spawn_command_args_options) with [`cross-spawn`](https://github.com/moxystudio/node-cross-spawn) (for better compatability with Windows).
- Drop existing connections before dropping the database via `yarn db:reset` (see `scripts/reset.js`).