### PR TITLE
Move validation errors to mutation payloads

### DIFF
--- a/api/schema.graphql
+++ b/api/schema.graphql
@@ -156,6 +156,7 @@ input DeleteUserInput {
 
 type UpsertStoryPayload {
   story: Story
+  errors: [[String!]!]!
   clientMutationId: String
 }
 

--- a/api/src/context.ts
+++ b/api/src/context.ts
@@ -8,12 +8,10 @@ import DataLoader from "dataloader";
 import { Request } from "express";
 
 import db, { User, Story, Comment } from "./db";
-import { Validator } from "./validator";
 import { mapTo, mapToMany, mapToValues } from "./utils";
-import { UnauthorizedError, ForbiddenError, ValidationError } from "./error";
+import { UnauthorizedError, ForbiddenError } from "./error";
 
 export class Context {
-  readonly errors: Array<{ key: string; message: string }> = [];
   private readonly req: Request;
 
   constructor(req: Request) {
@@ -49,36 +47,6 @@ export class Context {
 
     if (check && !check(this.req.user)) {
       throw new ForbiddenError();
-    }
-  }
-
-  /*
-   * Validation
-   * ------------------------------------------------------------------------ */
-
-  addError(key: string, message: string): void {
-    this.errors.push({ key, message });
-  }
-
-  validate<Input>(
-    input: Input,
-    config?: (validator: Validator<Input>) => Validator<Input>,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  ): Record<string, any> | undefined {
-    if (config) {
-      const { data, errors } = config(new Validator(input));
-      errors.forEach((err) => this.addError(err.key, err.message));
-      this.errors.push(...errors);
-
-      if (this.errors.length > 0) {
-        throw new ValidationError(this.errors);
-      }
-
-      return data;
-    }
-
-    if (this.errors.length) {
-      throw new ValidationError(this.errors);
     }
   }
 

--- a/api/src/error.ts
+++ b/api/src/error.ts
@@ -4,31 +4,6 @@
  * @copyright 2016-present Kriasoft (https://git.io/vMINh)
  */
 
-export type ValidationErrorEntry = {
-  key: string;
-  message: string;
-};
-
-export class ValidationError extends Error {
-  readonly code = 400;
-  state: { [key: string]: string[] };
-
-  constructor(errors: Array<ValidationErrorEntry>) {
-    super("The request is invalid.");
-    this.state = errors.reduce((result: { [key: string]: string[] }, error) => {
-      if (Object.prototype.hasOwnProperty.call(result, error.key)) {
-        result[error.key].push(error.message);
-      } else {
-        Object.defineProperty(result, error.key, {
-          value: [error.message],
-          enumerable: true,
-        });
-      }
-      return result;
-    }, {});
-  }
-}
-
 export class UnauthorizedError extends Error {
   readonly code = 401;
 

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -42,13 +42,7 @@ api.use(
     pretty: process.env.NODE_ENV !== "production",
     customFormatErrorFn: (err) => {
       console.error(err.originalError || err);
-      return {
-        message: err.message,
-        code: err.originalError?.code,
-        state: err.originalError?.state,
-        locations: err.locations,
-        path: err.path,
-      };
+      return err;
     },
   })),
 );

--- a/api/src/utils/__snapshots__/validator.test.ts.snap
+++ b/api/src/utils/__snapshots__/validator.test.ts.snap
@@ -1,0 +1,57 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`validate({"email":"err","displayName":"err","website":"err"}) 1`] = `
+Object {
+  "display_name": "err",
+  "email": "err",
+  "website": "err",
+}
+`;
+
+exports[`validate({"email":"err","displayName":"err","website":"err"}) 2`] = `
+Array [
+  Array [
+    "email",
+    "The email address is invalid.",
+  ],
+  Array [
+    "displayName",
+    "Invalid length.",
+  ],
+  Array [
+    "website",
+    "The URL is invalid.",
+  ],
+]
+`;
+
+exports[`validate({"email":"test@example.com","displayName":"test","website":"https://example.com"}) 1`] = `
+Object {
+  "display_name": "test",
+  "email": "test@example.com",
+  "website": "https://example.com",
+}
+`;
+
+exports[`validate({"email":"test@example.com","displayName":"test","website":"https://example.com"}) 2`] = `Array []`;
+
+exports[`validate({}) 1`] = `
+Object {
+  "display_name": undefined,
+  "email": undefined,
+  "website": undefined,
+}
+`;
+
+exports[`validate({}) 2`] = `
+Array [
+  Array [
+    "email",
+    "The email field cannot be empty.",
+  ],
+  Array [
+    "displayName",
+    "The display_name field cannot be empty.",
+  ],
+]
+`;

--- a/api/src/utils/index.ts
+++ b/api/src/utils/index.ts
@@ -9,3 +9,4 @@ export * from "./map";
 export * from "./relay";
 export * from "./type";
 export * from "./username";
+export * from "./validator";

--- a/api/src/utils/validator.test.ts
+++ b/api/src/utils/validator.test.ts
@@ -1,0 +1,34 @@
+import { validate } from "./validator";
+
+[
+  {},
+  {
+    email: "test@example.com",
+    displayName: "test",
+    website: "https://example.com",
+  },
+  {
+    email: "err",
+    displayName: "err",
+    website: "err",
+  },
+].forEach((input) => {
+  test(`validate(${JSON.stringify(input)})`, () => {
+    const { data, errors } = validate(input, (x) =>
+      x
+        .field("email")
+        .isRequired()
+        .isEmail()
+
+        .field("displayName", { as: "display_name" })
+        .isRequired()
+        .isLength({ min: 4 })
+
+        .field("website")
+        .isURL(),
+    );
+
+    expect(data).toMatchSnapshot();
+    expect(errors).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
- Improve generics usage in `validate(input, x => ...)` utility function, add some unit tests
- Move it from `src/validator.ts` to `src/utils/validator.ts`
- Remove `ctx.validate(input, ...)` in favor of calling this helper function directly
- Move validation errors to mutation payloads. For example:

```js
import { validate } from "../utils";

// ...

async mutateAndGetPayload(input, ctx: Context) {
  // Validate and sanitize user input
  const { data, errors } = validate(input, (x) =>
    x
      .field("title", { trim: true })
      .isRequired()
      .isLength({ min: 5, max: 80 })

      .field("text", { alias: "URL or text", trim: true })
      .isRequired()
      .isLength({ min: 10, max: 1000 }),
  );

  if (errors.length > 0) {
    return { errors };
  }

  // ...
}
```

```graphql
mutation {
  upsertStory(input: { title: "test" }) {
    story {
      id
      title
      text
    }
    errors
  }
}
```
```json
{
  "data": {
    "upsertStory": {
      "story": null,
      "errors": [
        [
          "title",
          "The title field must be between 5 and 80 characters long."
        ],
        [
          "text",
          "The text field cannot be empty."
        ]
      ]
    }
  }
}
```