### PR TITLE
Rename "auth" middleware to "session"

### DIFF
--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -9,13 +9,13 @@ import { express as voyager } from "graphql-voyager/middleware";
 import express, { Router, Request, Response } from "express";
 
 import env from "./env";
-import { auth } from "./auth";
+import { session } from "./session";
 import { schema } from "./schema";
 import { Context } from "./context";
 
 export const api = Router();
 
-api.use(auth);
+api.use(session);
 
 // Generates interactive UML diagram for the API schema
 // https://github.com/APIs-guru/graphql-voyager

--- a/api/src/session.ts
+++ b/api/src/session.ts
@@ -73,7 +73,7 @@ function signOut(res: Response): void {
   res.clearCookie(env.JWT_COOKIE);
 }
 
-export const auth: RequestHandler = async (req, res, next) => {
+export const session: RequestHandler = async function session(req, res, next) {
   try {
     req.user = await getUser(req);
     req.signIn = signIn.bind(undefined, res);


### PR DESCRIPTION
```js
import { session } from "./session"; // previously import { auth } from "./auth";

const api = new Router();

api.use(session);
```