### PR TITLE
Fix --env not working with `yarn deploy`

### DIFF
--- a/api/scripts/deploy.ts
+++ b/api/scripts/deploy.ts
@@ -14,10 +14,13 @@ import spawn from "cross-spawn";
 import minimist from "minimist";
 
 import env from "../src/env";
-import { name } from "../package.json";
+import pkg from "../package.json";
 
-const args = minimist(process.argv.slice(3));
+const args = minimist(process.argv.slice(2));
 const version = args.version ?? os.userInfo().username;
+const source = `gs://${process.env.PKG_BUCKET}/${pkg.name}_${version}.zip`;
+
+console.log(`Deploying ${source} to ${env.APP_ENV}...`);
 
 const envVars = [
   `APP_NAME=${env.APP_NAME}`,
@@ -29,7 +32,7 @@ const envVars = [
   `PGUSER=${env.PGUSER}`,
   `PGPASSWORD=${env.PGPASSWORD}`,
   `PGDATABASE=${env.PGDATABASE}`,
-  `PGAPPNAME=${name}_${version}`,
+  `PGAPPNAME=${pkg.name}_${version}`,
 ];
 
 spawn.sync(
@@ -38,13 +41,13 @@ spawn.sync(
     `--project=${process.env.GOOGLE_CLOUD_PROJECT}`,
     `functions`,
     `deploy`,
-    name,
+    pkg.name,
     `--region=${process.env.GOOGLE_CLOUD_REGION}`,
     `--allow-unauthenticated`,
-    `--entry-point=${name}`,
+    `--entry-point=${pkg.name}`,
     `--memory=2GB`,
     `--runtime=nodejs12`,
-    `--source=gs://${process.env.PKG_BUCKET}/${name}_${version}.zip`,
+    `--source=${source}`,
     `--timeout=30`,
     `--set-env-vars=${envVars.join(",")}`,
     `--trigger-http`,

--- a/env/index.cjs
+++ b/env/index.cjs
@@ -10,7 +10,8 @@ const path = require("path");
 const dotenv = require("dotenv");
 const minimist = require("minimist");
 
-const { env = "dev" } = minimist(process.argv.slice(2));
+const args = minimist(process.argv.slice(2));
+const env = args.env || minimist(args._).env || "dev";
 
 dotenv.config({ path: path.resolve(__dirname, `.env.${env}.override`) });
 dotenv.config({ path: path.resolve(__dirname, `.env.${env}`) });


### PR DESCRIPTION
#### `api`

```bash
$ yarn deploy              # Same as `yarn deploy --env=dev`
$ yarn deploy --env=dev    # Deploys gs://pkg.example.com/api_{version}.zip to https://example.com
$ yarn deploy --env=test   # Deploys gs://pkg.example.com/api_{version}.zip to https://test.example.com
$ yarn deploy --env=prod   # Deploys gs://pkg.example.com/api_{version}.zip to https://dev.example.com
```