### PR TITLE
Add .eslintrc.js to the root

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,72 @@
+/**
+ * ESLint configuration
+ *
+ * @see https://eslint.org/docs/user-guide/configuring
+ * @copyright 2016-present Kriasoft (https://git.io/vMINh)
+ *
+ * @type {import("eslint").Linter.Config}
+ */
+
+module.exports = {
+  root: true,
+
+  env: {
+    es6: true,
+    node: true,
+  },
+
+  extends: ["eslint:recommended", "prettier"],
+
+  parserOptions: {
+    ecmaVersion: 2020,
+  },
+
+  overrides: [
+    {
+      files: ["*.ts", "*.tsx"],
+      parser: "@typescript-eslint/parser",
+      extends: [
+        "plugin:@typescript-eslint/recommended",
+        "prettier/@typescript-eslint",
+      ],
+      plugins: ["@typescript-eslint"],
+      parserOptions: {
+        sourceType: "module",
+        warnOnUnsupportedTypeScriptVersion: true,
+      },
+    },
+    {
+      files: ["*.tsx"],
+      extends: ["prettier/react"],
+      plugins: ["jsx-a11y", "react", "react-hooks"],
+      env: {
+        browser: true,
+      },
+      parserOptions: {
+        ecmaFeatures: {
+          jsx: true,
+        },
+      },
+      settings: {
+        react: {
+          version: "detect",
+        },
+      },
+    },
+    {
+      files: ["*.test.ts", "*.test.tsx"],
+      env: {
+        jest: true,
+      },
+    },
+  ],
+
+  ignorePatterns: [
+    "/.git",
+    "/**/__snapshots__",
+    "/*/dist",
+    "/*/node_modules",
+    "/api/lib",
+    "/coverage",
+  ],
+};

--- a/.pnp.js
+++ b/.pnp.js
@@ -86,6 +86,10 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
         "npm:14.6.0"
       ],
       [
+        "@types/prettier",
+        "npm:2.0.2"
+      ],
+      [
         "@typescript-eslint/eslint-plugin",
         "virtual:0460f86c7587ee75dac643681550c044e8047ba46e219a5baac054fc0fea2d0af97a9bd3fe4b22de0884797215e0a1a4368bb60f9ef7087a69c4008789f4e032#npm:3.9.1"
       ],
@@ -166,6 +170,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@types/faker", "npm:4.1.12"],
             ["@types/inquirer", "npm:7.3.0"],
             ["@types/node", "npm:14.6.0"],
+            ["@types/prettier", "npm:2.0.2"],
             ["@typescript-eslint/eslint-plugin", "virtual:0460f86c7587ee75dac643681550c044e8047ba46e219a5baac054fc0fea2d0af97a9bd3fe4b22de0884797215e0a1a4368bb60f9ef7087a69c4008789f4e032#npm:3.9.1"],
             ["@typescript-eslint/parser", "virtual:0460f86c7587ee75dac643681550c044e8047ba46e219a5baac054fc0fea2d0af97a9bd3fe4b22de0884797215e0a1a4368bb60f9ef7087a69c4008789f4e032#npm:3.9.1"],
             ["@yarnpkg/pnpify", "virtual:0460f86c7587ee75dac643681550c044e8047ba46e219a5baac054fc0fea2d0af97a9bd3fe4b22de0884797215e0a1a4368bb60f9ef7087a69c4008789f4e032#npm:2.1.0"],
@@ -4030,6 +4035,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@types/faker", "npm:4.1.12"],
             ["@types/inquirer", "npm:7.3.0"],
             ["@types/node", "npm:14.6.0"],
+            ["@types/prettier", "npm:2.0.2"],
             ["@typescript-eslint/eslint-plugin", "virtual:0460f86c7587ee75dac643681550c044e8047ba46e219a5baac054fc0fea2d0af97a9bd3fe4b22de0884797215e0a1a4368bb60f9ef7087a69c4008789f4e032#npm:3.9.1"],
             ["@typescript-eslint/parser", "virtual:0460f86c7587ee75dac643681550c044e8047ba46e219a5baac054fc0fea2d0af97a9bd3fe4b22de0884797215e0a1a4368bb60f9ef7087a69c4008789f4e032#npm:3.9.1"],
             ["@yarnpkg/pnpify", "virtual:0460f86c7587ee75dac643681550c044e8047ba46e219a5baac054fc0fea2d0af97a9bd3fe4b22de0884797215e0a1a4368bb60f9ef7087a69c4008789f4e032#npm:2.1.0"],

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,28 @@
+/**
+ * Prettier configuration
+ *
+ * @see https://prettier.io/docs/en/configuration
+ * @copyright 2016-present Kriasoft (https://git.io/vMINh)
+ *
+ * @type {import("prettier").RequiredOptions}
+ */
+
+module.exports = {
+  printWidth: 80,
+  tabWidth: 2,
+  useTabs: false,
+  semi: true,
+  singleQuote: false,
+  quoteProps: "as-needed",
+  jsxSingleQuote: false,
+  trailingComma: "all",
+  bracketSpacing: true,
+  jsxBracketSameLine: false,
+  arrowParens: "always",
+  requirePragma: false,
+  insertPragma: false,
+  proseWrap: "preserve",
+  htmlWhitespaceSensitivity: "css",
+  vueIndentScriptAndStyle: false,
+  endOfLine: "lf",
+};

--- a/api/babel.config.js
+++ b/api/babel.config.js
@@ -5,14 +5,14 @@
  * @see https://babeljs.io/docs/en/babel-preset-typescript
  * @copyright 2016-present Kriasoft (https://git.io/vMINh)
  *
- * @type {import('@babel/core').TransformOptions}
+ * @type {import("@babel/core").TransformOptions}
  */
 
 module.exports = {
   presets: [
     [
       "@babel/preset-env",
-      /** @lends {import('@babel/preset-env').Options} */ {
+      /** @lends {import("@babel/preset-env").Options} */ {
         // https://cloud.google.com/functions/docs/concepts/nodejs-runtime
         targets: { node: "12" },
         useBuiltIns: "usage",

--- a/api/package.json
+++ b/api/package.json
@@ -1,6 +1,7 @@
 {
   "name": "api",
   "version": "0.0.0",
+  "private": true,
   "license": "MIT",
   "author": "Kriasoft (https://github.com/kriasoft)",
   "main": "lib/index.js",
@@ -86,15 +87,9 @@
   "engines": {
     "node": ">=12"
   },
-  "private": true,
   "nodemonConfig": {
     "ext": "ts,json,hbs",
     "exec": "babel-node -x .ts -r env"
-  },
-  "eslintConfig": {
-    "ignorePatterns": [
-      "/lib/"
-    ]
   },
   "jest": {
     "testPathIgnorePatterns": [

--- a/api/src/auth/connect.ts
+++ b/api/src/auth/connect.ts
@@ -24,7 +24,7 @@ export default async function connect(
       .where({
         "identities.id": identity.id,
         "identities.provider": identity.provider,
-      } as any)
+      } as any) // eslint-disable-line @typescript-eslint/no-explicit-any
       .first<User>("users.*");
   }
 

--- a/db/package.json
+++ b/db/package.json
@@ -1,6 +1,7 @@
 {
   "name": "db",
   "version": "0.0.0",
+  "private": true,
   "license": "MIT",
   "author": "Kriasoft (https://github.com/kriasoft)",
   "scripts": {
@@ -34,6 +35,5 @@
     "nanoid": "^3.1.12",
     "pg": "^8.3.2",
     "prettier": "^2.0.5"
-  },
-  "private": true
+  }
 }

--- a/env/package.json
+++ b/env/package.json
@@ -1,6 +1,7 @@
 {
   "name": "env",
   "version": "0.0.0",
+  "private": true,
   "license": "MIT",
   "author": "Kriasoft (https://github.com/kriasoft)",
   "main": "index.cjs",
@@ -8,6 +9,5 @@
   "dependencies": {
     "dotenv": "^8.2.0",
     "minimist": "^1.2.5"
-  },
-  "private": true
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "app",
   "version": "0.0.0",
+  "private": true,
   "license": "MIT",
   "author": "Kriasoft (https://github.com/kriasoft)",
   "workspaces": [
@@ -25,6 +26,7 @@
     "@types/faker": "^4.1.12",
     "@types/inquirer": "^7.3.0",
     "@types/node": "^14.6.0",
+    "@types/prettier": "^2.0.2",
     "@typescript-eslint/eslint-plugin": "^3.9.1",
     "@typescript-eslint/parser": "^3.9.1",
     "@yarnpkg/pnpify": "2.1.0",
@@ -41,61 +43,6 @@
     "pg": "^8.3.2",
     "prettier": "2.0.5",
     "typescript": "3.9.7"
-  },
-  "engines": {
-    "node": ">=12"
-  },
-  "private": true,
-  "prettier": {
-    "printWidth": 80,
-    "tabWidth": 2,
-    "useTabs": false,
-    "semi": true,
-    "singleQuote": false,
-    "quoteProps": "as-needed",
-    "jsxSingleQuote": false,
-    "trailingComma": "all",
-    "bracketSpacing": true,
-    "jsxBracketSameLine": false,
-    "arrowParens": "always",
-    "requirePragma": false,
-    "insertPragma": false,
-    "proseWrap": "preserve",
-    "htmlWhitespaceSensitivity": "css",
-    "vueIndentScriptAndStyle": false,
-    "endOfLine": "lf"
-  },
-  "eslintConfig": {
-    "root": true,
-    "env": {
-      "es6": true,
-      "node": true
-    },
-    "extends": [
-      "eslint:recommended",
-      "prettier"
-    ],
-    "parserOptions": {
-      "ecmaVersion": 2020
-    },
-    "overrides": [
-      {
-        "files": [
-          "*.ts",
-          "*.tsx"
-        ],
-        "parser": "@typescript-eslint/parser",
-        "extends": [
-          "plugin:@typescript-eslint/recommended"
-        ],
-        "plugins": [
-          "@typescript-eslint"
-        ],
-        "parserOptions": {
-          "sourceType": "module"
-        }
-      }
-    ]
   },
   "husky": {
     "hooks": {

--- a/proxy/package.json
+++ b/proxy/package.json
@@ -1,6 +1,7 @@
 {
   "name": "proxy",
   "version": "0.0.0",
+  "private": true,
   "license": "MIT",
   "author": "Kriasoft (https://github.com/kriasoft)",
   "scripts": {
@@ -25,9 +26,7 @@
     "webpack": "5.0.0-beta.28",
     "webpack-cli": "webpack/webpack-cli#workspace=webpack-cli&commit=86dfe514a5b5de38f631a02e5211d10f32c536b9"
   },
-  "private": true,
   "eslintConfig": {
-    "ignorePatterns": "/dist/",
     "overrides": [
       {
         "files": [

--- a/proxy/webpack.config.js
+++ b/proxy/webpack.config.js
@@ -9,8 +9,8 @@ const path = require("path");
 
 /**
  * @param {Record<string, boolean> | undefined} env
- * @param {{ mode: 'production' | 'development' }} options
- * @returns {import('webpack').Configuration}
+ * @param {{ mode: "production" | "development" }} options
+ * @returns {import("webpack").Configuration}
  */
 module.exports = function config(env, options) {
   const isEnvProduction = options.mode === "production";

--- a/yarn.lock
+++ b/yarn.lock
@@ -2280,7 +2280,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/prettier@npm:^2.0.0":
+"@types/prettier@npm:^2.0.0, @types/prettier@npm:^2.0.2":
   version: 2.0.2
   resolution: "@types/prettier@npm:2.0.2"
   checksum: f661ba2c6312724a9513e63891c668cba33547e259e28ddca97c8107a9d5094aab51b4dd83e17fc8fa37e69c7ac6f2c447b8da36a7e579abf8b804c1e0593767
@@ -3261,6 +3261,7 @@ __metadata:
     "@types/faker": ^4.1.12
     "@types/inquirer": ^7.3.0
     "@types/node": ^14.6.0
+    "@types/prettier": ^2.0.2
     "@typescript-eslint/eslint-plugin": ^3.9.1
     "@typescript-eslint/parser": ^3.9.1
     "@yarnpkg/pnpify": 2.1.0


### PR DESCRIPTION
- Move ESLint configuration from `package.json` to `.eslintrc.js` as it grows in size
- Add more default settings to ESLint configuration
- List all ESLint ignore rules in one place `.eslintrc.js` -> `ignoreSettings`
- Move Prettier configuration to `.prettierrc.js` in order to match ESLint configuration approach
- Move `package.json->private` setting to the top, right after `package.json->version`