### PR TITLE
Application routing via Cloudflare Workers

### DIFF
--- a/.pnp.js
+++ b/.pnp.js
@@ -15169,6 +15169,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["proxy", "workspace:proxy"],
             ["@babel/core", "npm:7.11.6"],
             ["@cloudflare/workers-types", "npm:2.0.0"],
+            ["@types/jest", "npm:26.0.13"],
             ["@types/minimist", "npm:1.2.0"],
             ["babel-loader", "virtual:a79575648ee6aa3987b96e1ae7433105b0879543b0ca8beadcdded635903a9da857d9b356ae961befa550717968a1c44f6edc9144256ce4ea622aceeee59abdd#npm:8.1.0"],
             ["core-js", "npm:3.6.5"],

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,6 +19,7 @@
   },
   "cSpell.ignoreWords": [
     "abcdefghijklmnopqrstuvwxyz",
+    "cloudfunctions",
     "cloudsql",
     "corejs",
     "dataloader",

--- a/babel.config.js
+++ b/babel.config.js
@@ -71,7 +71,7 @@ module.exports = function config(api) {
           [
             "@babel/preset-env",
             {
-              modules: false,
+              modules: api.env() === "test" ? "auto" : false,
               loose: true,
               targets: {
                 browsers: "last 1 Chrome versions",

--- a/env/.env
+++ b/env/.env
@@ -15,6 +15,6 @@ PKG_BUCKET=pkg.example.com
 
 # Cloudflare
 # https://dash.cloudflare.com/
-CF_ACCOUNT_ID=
-CF_ZONE_ID=
-CF_TOKEN=
+CLOUDFLARE_ACCOUNT_ID=
+CLOUDFLARE_ZONE_ID=
+CLOUDFLARE_API_TOKEN=

--- a/proxy/bindings.d.ts
+++ b/proxy/bindings.d.ts
@@ -5,6 +5,5 @@
  * @copyright 2016-present Kriasoft (https://git.io/vMINh)
  */
 
-declare global {
-  const MY_ENV_VAR: string;
-}
+declare const GOOGLE_CLOUD_REGION: string;
+declare const GOOGLE_CLOUD_PROJECT: { prod: string; test: string; dev: string };

--- a/proxy/package.json
+++ b/proxy/package.json
@@ -15,7 +15,6 @@
   "dependencies": {
     "@babel/core": "^7.11.6",
     "@cloudflare/workers-types": "^2.0.0",
-    "@types/minimist": "^1.2.0",
     "babel-loader": "^8.1.0",
     "core-js": "^3.6.5",
     "cross-spawn": "^7.0.3",
@@ -26,5 +25,9 @@
     "typescript": "4.0.2",
     "webpack": "5.0.0-beta.28",
     "webpack-cli": "webpack/webpack-cli#workspace=webpack-cli&commit=86dfe514a5b5de38f631a02e5211d10f32c536b9"
+  },
+  "devDependencies": {
+    "@types/jest": "^26.0.13",
+    "@types/minimist": "^1.2.0"
   }
 }

--- a/proxy/parse.test.ts
+++ b/proxy/parse.test.ts
@@ -1,0 +1,18 @@
+/**
+ * @copyright 2016-present Kriasoft (https://git.io/vMINh)
+ */
+
+import { parseHostname } from "./parse";
+
+[
+  ["example.com", "prod", undefined],
+  ["test.example.com", "test", undefined],
+  ["123-test.example.com", "test", "123"],
+  ["dev.example.com", "dev", undefined],
+  ["123-dev.example.com", "dev", "123"],
+].forEach(([hostname, env, ver]) => {
+  it(`parseHostname(${hostname}) => [${env}, ${ver}]`, () => {
+    const result = parseHostname(hostname as string);
+    expect(result).toStrictEqual([env, ver]);
+  });
+});

--- a/proxy/parse.ts
+++ b/proxy/parse.ts
@@ -1,0 +1,27 @@
+/**
+ * Extracts environment name and version number from the URL hostname.
+ *
+ *   "example.com" => ["prod", undefined]
+ *   "test.example.com" => ["test", undefined]
+ *   "123-test.example.com" => ["test", "123"]
+ *
+ * @copyright 2016-present Kriasoft (https://git.io/vMINh)
+ */
+
+export function parseHostname(
+  hostname: string,
+): ["prod" | "test" | "dev", string | undefined] {
+  const prefix = hostname.substring(0, hostname.indexOf("."));
+
+  for (const env of ["test", "dev"] as Array<"test" | "dev">) {
+    if (prefix === env) {
+      return [env, undefined];
+    }
+
+    if (prefix.endsWith(`-${env}`)) {
+      return [env, prefix.substring(0, prefix.length - env.length - 1)];
+    }
+  }
+
+  return ["prod", undefined];
+}

--- a/proxy/tsconfig.json
+++ b/proxy/tsconfig.json
@@ -46,7 +46,7 @@
     // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
     // "typeRoots": [],                       /* List of folders to include type definitions from. */
-    "types": ["@cloudflare/workers-types"],   /* Type declaration files to be included in compilation. */
+    "types": ["@cloudflare/workers-types", "jest"], /* Type declaration files to be included in compilation. */
     "allowSyntheticDefaultImports": true,     /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
     "esModuleInterop": true,                  /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
     // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */

--- a/scripts/build-api.js
+++ b/scripts/build-api.js
@@ -61,7 +61,7 @@ async function build() {
   }
 
   // Compile and bundle referenced workspaces
-  pkg.dependencies.db = "file:packages/db";
+  pkg.workspaces = ["packages/db"];
   for (const file of ["db/types.d.ts", "db/package.json"]) {
     const filePath = path.resolve(root, file);
     const fileName = `packages/${file.replace(/(\.d\.ts|\.ts)$/, ".js")}`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -12056,6 +12056,7 @@ fsevents@^1.2.7:
   dependencies:
     "@babel/core": ^7.11.6
     "@cloudflare/workers-types": ^2.0.0
+    "@types/jest": ^26.0.13
     "@types/minimist": ^1.2.0
     babel-loader: ^8.1.0
     core-js: ^3.6.5


### PR DESCRIPTION
- Add unit tests to `proxy` workspace
- Rename Cloudflare environment variables to match Terraform
  - `CF_ACCOUNT_ID` => `CLOUDFLARE_ACCOUNT_ID`
  - `CF_ZONE_ID` => `CLOUDFLARE_ZONE_ID`
  - `CF_TOKEN` => `CLOUDFLARE_API_TOKEN`
- Export `load(envName)` function from `env` module
- Update `proxy` module to handle URLs such as
  - `https://example.com`
  - `https://test.example.com` - test / QA deployment
  - `https://123-test.example.com` - review deployment per PR, where 123 is the PR number
- Improve `proxy` deployment script