### PR TITLE
Add `yarn deploy` script for "web"

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -82,18 +82,18 @@ the running instance of the app.
 
 ## How to Deploy
 
-Compile and bundle the code into `package.zip` (`build`), upload application
-bundle to Google Cloud Storage (`push`), and finally, deploy or re-deploy a
-Google Cloud Function straight from GCS (`deploy`).
+Compile and bundle the code into the `dist/api.zip` file (`yarn build`), upload
+it to Google Cloud Storage (`yarn push`), and finally, deploy or re-deploy
+the Google Cloud Function straight from GCS (`yarn deploy`).
 
 ```
-$ yarn build
-$ yarn push [--version=#0]
-$ yarn deploy [--version=#0] [--env=#1]
+$ yarn api:build
+$ yarn api:push [--version=#0]
+$ yarn api:deploy [--version=#0] [--env=#1]
 ```
 
-**NOTE**: These three separate steps are required in order to optimize the CI/CD
-workflows.
+**NOTE**: These three separate steps are necessary in order to optimize the CI/CD
+workflows (see `.github/workflows`).
 
 ## License
 

--- a/scripts/bundle-web.js
+++ b/scripts/bundle-web.js
@@ -1,0 +1,57 @@
+/**
+ * Bundles the "web" package into "dist/web.zip".
+ *
+ * @see https://www.archiverjs.com/
+ * @see https://github.com/sindresorhus/globby
+ * @copyright 2016-present Kriasoft (https://git.io/vMINh)
+ */
+
+const fs = require("fs");
+const path = require("path");
+const globby = require("globby");
+const makeDir = require("make-dir");
+const archiver = require("archiver");
+
+const pkg = require("../web/package.json");
+const bundleYarn = require("./bundle-yarn");
+
+// Match patterns of the files that needs to be included into the bundle
+const match = [".next/**/*", "!.next/cache", "next.config.js", "server.js"];
+
+// Location of the output bundle
+const root = path.resolve(__dirname, "..");
+const dest = path.join(root, "dist/web.zip");
+const cwd = path.resolve(root, "web");
+
+async function build() {
+  // Ensure that the destination folder exists
+  await makeDir(path.dirname(dest));
+
+  // Create a new .zip archive
+  const zip = archiver("zip");
+  zip.pipe(fs.createWriteStream(dest));
+
+  // Compiled and bundle application source code
+  for await (const entry of globby.stream(match, { cwd, objectMode: true })) {
+    console.log(entry.path);
+    zip.file(path.resolve(cwd, entry.path), { name: entry.path });
+  }
+
+  // Clean up and bundle package.json
+  delete pkg.scripts;
+  delete pkg.devDependencies;
+  delete pkg.eslintConfig;
+
+  console.log("package.json");
+  zip.append(JSON.stringify(pkg, null, "  "), { name: "package.json" });
+
+  await bundleYarn(zip);
+  await zip.finalize();
+
+  console.log(`Output: ${path.relative(root, dest)} ${zip.pointer()} bytes`);
+}
+
+build().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/deploy-web.js
+++ b/scripts/deploy-web.js
@@ -1,0 +1,62 @@
+/**
+ * Deploys application bundle to Google Cloud Functions (GCF). Usage:
+ *
+ *   $ yarn deploy [--version=#0] [--env=#1]
+ *
+ * @see https://cloud.google.com/functions
+ * @see https://cloud.google.com/sdk/gcloud/reference/functions/deploy
+ * @copyright 2016-present Kriasoft (https://git.io/vMINh)
+ */
+
+require("env");
+const spawn = require("cross-spawn");
+const minimist = require("minimist");
+const pkg = require("web/package.json");
+
+const { env } = process;
+const { version } = minimist(process.argv.slice(2), {
+  default: { version: process.env.VERSION },
+});
+
+const source = `gs://${process.env.PKG_BUCKET}/${pkg.name}_${version}.zip`;
+
+console.log(`Deploying ${source} to ${env.APP_ENV}...`);
+
+const envVars = [
+  `NODE_OPTIONS=--require ./.pnp.js`,
+  // `APP_NAME=${env.APP_NAME}`,
+  // `APP_ORIGIN=${env.APP_ORIGIN}`,
+  // `APP_ENV=${env.APP_ENV}`,
+  // `VERSION=${version}`,
+  // `JWT_SECRET=${env.JWT_SECRET}`,
+  // `GOOGLE_CLIENT_ID=${env.GOOGLE_CLIENT_ID}`,
+  // `GOOGLE_CLIENT_SECRET=${env.GOOGLE_CLIENT_SECRET}`,
+  // `PGHOST=/cloudsql/${env.PGSERVERNAME.replace(":", `:${region}:`)}`,
+  // `PGUSER=${env.PGUSER}`,
+  // `PGPASSWORD=${env.PGPASSWORD}`,
+  // `PGDATABASE=${env.PGDATABASE}`,
+  // `PGAPPNAME=${pkg.name}_${version}_${env.APP_ENV}`,
+];
+
+spawn(
+  "gcloud",
+  [
+    `--project=${env.GOOGLE_CLOUD_PROJECT}`,
+    `functions`,
+    `deploy`,
+    pkg.name,
+    `--region=${env.GOOGLE_CLOUD_REGION}`,
+    `--allow-unauthenticated`,
+    `--entry-point=${pkg.name}`,
+    `--memory=2GB`,
+    `--runtime=nodejs12`,
+    `--source=${source}`,
+    `--timeout=30`,
+    `--set-env-vars=${envVars.join(",")}`,
+    `--trigger-http`,
+  ],
+  { stdio: "inherit" },
+).on("error", (err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -14,7 +14,8 @@
     "globby": "^11.0.2",
     "got": "^11.8.1",
     "make-dir": "^3.1.0",
-    "minimist": "^1.2.5"
+    "minimist": "^1.2.5",
+    "web": "workspace:*"
   },
   "devDependencies": {
     "@types/archiver": "^5.1.0",

--- a/web/README.md
+++ b/web/README.md
@@ -16,6 +16,21 @@ $ yarn web:start                # Launch Next.js web app
 
 The app must become available on [`http://localhost:3000/`](http://localhost:3000/).
 
+## How to Deploy
+
+Compile and bundle the code into the `dist/web.zip` file (`yarn build`), upload
+it to Google Cloud Storage (`yarn push`), and finally, deploy or re-deploy
+the Google Cloud Function straight from GCS (`yarn deploy`).
+
+```
+$ yarn web:build
+$ yarn web:push [--version=#0]
+$ yarn web:deploy [--version=#0] [--env=#1]
+```
+
+**NOTE**: These three separate steps are necessary in order to optimize the CI/CD
+workflows (see `.github/workflows`).
+
 ## License
 
 Copyright © 2016-present Kriasoft. This source code is licensed under the MIT license found in the

--- a/web/package.json
+++ b/web/package.json
@@ -4,25 +4,29 @@
   "private": true,
   "license": "MIT",
   "author": "Kriasoft (https://github.com/kriasoft)",
+  "main": "server.js",
   "scripts": {
     "relay": "yarn relay-compiler --schema ../api/schema.graphql --language typescript --src . --exclude \"**/.next/**\" --exclude \"**/test/**\" --watchman false $@",
-    "build": "next build",
     "start": "node ./server",
+    "build": "del .next && next build && node ../scripts/bundle-web",
+    "push": "yarn push -r env ../dist/web.zip",
+    "deploy": "node ../scripts/deploy-web",
     "web:relay": "yarn workspace web run relay",
+    "web:start": "yarn workspace web run start",
     "web:build": "yarn workspace web run build",
-    "web:start": "yarn workspace web run start"
+    "web:push": "yarn workspace web run push",
+    "web:deploy": "yarn workspace web run deploy"
   },
   "dependencies": {
     "@babel/runtime": "^7.12.5",
     "@emotion/css": "^11.1.3",
     "@emotion/react": "^11.1.4",
     "@emotion/server": "^11.0.0",
-    "express": "^4.17.1",
     "next": "^10.0.5",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
-    "react-relay": "0.0.0-experimental-0b967d2e",
-    "relay-runtime": "^10.1.2"
+    "react-relay": "0.0.0-experimental-4c4107dd",
+    "relay-runtime": "^10.1.3"
   },
   "devDependencies": {
     "@emotion/babel-plugin": "^11.1.2",
@@ -35,12 +39,15 @@
     "@types/react-relay": "^7.0.17",
     "@types/relay-compiler": "^8.0.0",
     "@types/relay-runtime": "^10.1.7",
-    "babel-plugin-relay": "^10.1.2",
+    "babel-plugin-relay": "^10.1.3",
+    "del-cli": "^3.0.1",
+    "env": "workspace:*",
+    "express": "^4.17.1",
     "graphql": "^15.4.0",
     "http-proxy-middleware": "^1.0.6",
-    "relay-compiler": "^10.1.2",
+    "relay-compiler": "^10.1.3",
     "relay-compiler-language-typescript": "^13.0.2",
-    "relay-config": "^10.1.2",
+    "relay-config": "^10.1.3",
     "typescript": "4.1.3"
   },
   "eslintConfig": {
@@ -49,7 +56,7 @@
     ],
     "settings": {
       "react": {
-        "version": "17.0.0-rc.1"
+        "version": "17.0.1"
       }
     },
     "rules": {

--- a/web/pages/index.tsx
+++ b/web/pages/index.tsx
@@ -13,11 +13,12 @@ export default function Home(): JSX.Element {
       css={(theme) => css`
         margin-top: 40vh;
         text-align: center;
+        font-size: 4rem;
         font-weight: bold;
         font-family: ${theme.typography.fontFamily};
       `}
     >
-      Next.js app skeleton.
+      Welcome to <a href="/">Next.js web app</a>!
     </p>
   );
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5130,14 +5130,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"babel-plugin-relay@npm:^10.1.2":
-  version: 10.1.2
-  resolution: "babel-plugin-relay@npm:10.1.2"
+"babel-plugin-relay@npm:^10.1.3":
+  version: 10.1.3
+  resolution: "babel-plugin-relay@npm:10.1.3"
   dependencies:
     babel-plugin-macros: ^2.0.0
   peerDependencies:
     graphql: ^15.0.0
-  checksum: badc07c3ec4cbec598307787725c311a6731856876f0db0334911991f19d912537e737f391c94e92f23bdaec673af6aaec23ec4cd3314e87215aba07b782786c
+  checksum: d416479f9ad10b94f480ce20232c10e30d76c88ab5e5c7cc99baaeb057d3d45ebc8174abec2a4ec83e185658e1910e250c53c94cc4bf44e791c0b78d64317f80
   languageName: node
   linkType: hard
 
@@ -14091,18 +14091,18 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"react-relay@npm:0.0.0-experimental-0b967d2e":
-  version: 0.0.0-experimental-0b967d2e
-  resolution: "react-relay@npm:0.0.0-experimental-0b967d2e"
+"react-relay@npm:0.0.0-experimental-4c4107dd":
+  version: 0.0.0-experimental-4c4107dd
+  resolution: "react-relay@npm:0.0.0-experimental-4c4107dd"
   dependencies:
     "@babel/runtime": ^7.0.0
     fbjs: ^3.0.0
     nullthrows: ^1.1.1
-    relay-runtime: 10.1.2
+    relay-runtime: 10.1.3
     scheduler: ^0.19.1
   peerDependencies:
     react: ^16.9.0 || ^17
-  checksum: 1e870304541f5e91d212c086ec00a98af06ac751ae13182d0c3de0d8c45e6954b4a6af1e8e6524f725d82d995d8904002e84143a73eed7e4422a4bebffb4f29f
+  checksum: bd3c8e7e4ee70c4b6f5a1e0cd191f2f722e0b632adf0f10c96990fbbcd98c8f6df6c355c45333a376f558e272f574740048c829ed4d2b09ba969479f5e524164
   languageName: node
   linkType: hard
 
@@ -14420,9 +14420,9 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"relay-compiler@npm:^10.1.2":
-  version: 10.1.2
-  resolution: "relay-compiler@npm:10.1.2"
+"relay-compiler@npm:^10.1.3":
+  version: 10.1.3
+  resolution: "relay-compiler@npm:10.1.3"
   dependencies:
     "@babel/core": ^7.0.0
     "@babel/generator": ^7.5.0
@@ -14437,35 +14437,35 @@ fsevents@^1.2.7:
     glob: ^7.1.1
     immutable: ~3.7.6
     nullthrows: ^1.1.1
-    relay-runtime: 10.1.2
+    relay-runtime: 10.1.3
     signedsource: ^1.0.0
     yargs: ^15.3.1
   peerDependencies:
     graphql: ^15.0.0
   bin:
     relay-compiler: bin/relay-compiler
-  checksum: 7950a1554fa497f8da5b64cab5b4037c25ed97ac1733d815d4f2a90f1a0d492d7728c8c2a1329f52837746875fe63f37be0e1902396a3fe99541f9ba3ae251d8
+  checksum: 2bdfc3338bcdcaa2c03b84fcdd9a01f2882b54ce7059c61d8206ed8b6b9d7d6987df5ff88a02c2c8570d86bef64a16100164dfe8b5326917cd13bf92f02fbdc3
   languageName: node
   linkType: hard
 
-"relay-config@npm:^10.1.2":
-  version: 10.1.2
-  resolution: "relay-config@npm:10.1.2"
+"relay-config@npm:^10.1.3":
+  version: 10.1.3
+  resolution: "relay-config@npm:10.1.3"
   dependencies:
     cosmiconfig: ^5.0.5
   peerDependencies:
-    relay-compiler: 10.1.2
-  checksum: d275772881c57323a10e0160b852b85a6fe9c3ce530016fc9aff83d5669f9a583478045102de1d561d95a0ddbadb229d789a18f1276ec608dccb9292819a99dd
+    relay-compiler: 10.1.3
+  checksum: 49f0c812e3ec371d40bfbb345430a0ce7a8c2802ffbfb84c7e00a1fc2c2d8a8330c95a2f33c7d7d4e251318cacae53e2a3b68c3081fb84b424b13a9e8b546018
   languageName: node
   linkType: hard
 
-"relay-runtime@npm:10.1.2, relay-runtime@npm:^10.1.2":
-  version: 10.1.2
-  resolution: "relay-runtime@npm:10.1.2"
+"relay-runtime@npm:10.1.3, relay-runtime@npm:^10.1.3":
+  version: 10.1.3
+  resolution: "relay-runtime@npm:10.1.3"
   dependencies:
     "@babel/runtime": ^7.0.0
     fbjs: ^3.0.0
-  checksum: 0d9e38e85ee6490c9b5330757f07071111e152f09f91b8d4b632284b41d17e2f7354380eeb0964f7a37a339e82ad2dbb1a91844b37ca87a07c17aa8ad71dd267
+  checksum: 5d6ae8e3d34d28179b26d97799901e0b5971e4272b8835b325b3f365196a57d5163deaa40f4af9f700945dbed5da268ee711cb2b61fcab54182343c2f2d85f66
   languageName: node
   linkType: hard
 
@@ -14997,6 +14997,7 @@ resolve@^1.18.1:
     got: ^11.8.1
     make-dir: ^3.1.0
     minimist: ^1.2.5
+    web: "workspace:*"
   languageName: unknown
   linkType: soft
 
@@ -17004,7 +17005,7 @@ typescript@^3.0.0:
   languageName: node
   linkType: hard
 
-"web@workspace:web":
+"web@workspace:*, web@workspace:web":
   version: 0.0.0-use.local
   resolution: "web@workspace:web"
   dependencies:
@@ -17022,18 +17023,20 @@ typescript@^3.0.0:
     "@types/react-relay": ^7.0.17
     "@types/relay-compiler": ^8.0.0
     "@types/relay-runtime": ^10.1.7
-    babel-plugin-relay: ^10.1.2
+    babel-plugin-relay: ^10.1.3
+    del-cli: ^3.0.1
+    env: "workspace:*"
     express: ^4.17.1
     graphql: ^15.4.0
     http-proxy-middleware: ^1.0.6
     next: ^10.0.5
     react: ^17.0.1
     react-dom: ^17.0.1
-    react-relay: 0.0.0-experimental-0b967d2e
-    relay-compiler: ^10.1.2
+    react-relay: 0.0.0-experimental-4c4107dd
+    relay-compiler: ^10.1.3
     relay-compiler-language-typescript: ^13.0.2
-    relay-config: ^10.1.2
-    relay-runtime: ^10.1.2
+    relay-config: ^10.1.3
+    relay-runtime: ^10.1.3
     typescript: 4.1.3
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
Add `yarn build`, `yarn push`, and `yarn deploy` scripts to the `web` (Next.js) project that deploys the app to Google Cloud Functions (GCF). Also, update Relay from `10.1.2` to `10.1.3`.

#### How to Deploy

Compile and bundle the code into the `dist/web.zip` file (`yarn build`), upload
it to Google Cloud Storage (`yarn push`), and finally, deploy or re-deploy
the Google Cloud Function straight from GCS (`yarn deploy`).

```
$ yarn web:build
$ yarn web:push [--version=#0]
$ yarn web:deploy [--version=#0] [--env=#1]
```

**NOTE**: These three separate steps are necessary in order to optimize the CI/CD
workflows (see `.github/workflows`).