### PR TITLE
Hydrate / dehydrate GraphQL API query response

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,9 @@ always pull and merge updates from the "upstream" repository back into your
 project by running:
 
 ```bash
-$ git fetch seed            # Fetch Node.js Starter Kit (upstream) repository
+$ git fetch seed                # Fetch Node.js Starter Kit (upstream) repository
 $ git checkout main             # Switch to the main branch (or, master branch)
-$ git merge seed/main       # Merge upstream/master into the local branch
+$ git merge seed/main           # Merge upstream/master into the local branch
 ```
 
 In order to update Yarn and other dependencies to the latest versions, run:

--- a/web/common/App.tsx
+++ b/web/common/App.tsx
@@ -4,24 +4,24 @@
 
 import * as React from "react";
 import { Update, Action } from "history";
+import { Environment } from "relay-runtime";
 import { RelayEnvironmentProvider } from "react-relay/hooks";
 
 import { ErrorPage } from "./ErrorPage";
 import { AppStyles } from "./AppStyles";
 import { AppToolbar } from "./AppToolbar";
 import { AppContent } from "./AppContent";
-import { createRelay } from "../core/relay";
 import { resolveRoute } from "../core/router";
 import { History, HistoryContext, LocationContext } from "../core/history";
 import type { RouteResponse } from "../core/router";
 
 export type AppProps = {
   history: History;
+  relay: Environment;
 };
 
 export class App extends React.Component<AppProps> {
   state = {
-    relay: createRelay(),
     route: undefined as RouteResponse | undefined,
     location: this.props.history.location,
     error: undefined as Error | undefined,
@@ -57,7 +57,7 @@ export class App extends React.Component<AppProps> {
   renderPath = async (ctx: Update): Promise<void> => {
     resolveRoute({
       path: ctx.location.pathname,
-      relay: this.state.relay,
+      relay: this.props.relay,
     }).then((route) => {
       if (route.error) console.error(route.error);
       this.setState({ route, location: ctx.location, error: route.error });
@@ -66,14 +66,14 @@ export class App extends React.Component<AppProps> {
 
   render(): JSX.Element {
     const { history } = this.props;
-    const { relay, route, location, error } = this.state;
+    const { route, location, error } = this.state;
 
     if (error) {
       return <ErrorPage error={error} />;
     }
 
     return (
-      <RelayEnvironmentProvider environment={relay}>
+      <RelayEnvironmentProvider environment={this.props.relay}>
         <HistoryContext.Provider value={history}>
           <LocationContext.Provider value={location}>
             <AppStyles />

--- a/web/core/relay.ts
+++ b/web/core/relay.ts
@@ -7,12 +7,13 @@ import { Environment, Network, RecordSource, Store } from "relay-runtime";
 type Config = {
   baseUrl?: string;
   request?: Request;
+  records?: ConstructorParameters<typeof RecordSource>[0];
 };
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 export function createRelay(config: Config = {}): Environment {
-  const recordSource = new RecordSource();
+  const recordSource = new RecordSource(config.records);
   const store = new Store(recordSource);
   const baseUrl = config.baseUrl || "";
 

--- a/web/core/router.ts
+++ b/web/core/router.ts
@@ -16,17 +16,16 @@ export async function resolveRoute(
     for (let i = 0, route; i < routes.length, (route = routes[i]); i++) {
       if (route.path !== ctx.path) continue;
 
+      const { query } = route;
+      let { variables } = route;
+
       // Prepare GraphQL query variables
-      const variables =
-        typeof route.variables === "function"
-          ? route.variables(ctx)
-          : route.variables;
+      variables = typeof variables === "function" ? variables(ctx) : variables;
 
       // Fetch GraphQL query response and load React component in parallel
       const [component, data] = await Promise.all([
-        route.component && route.component().then((x) => x.default),
-        route.query &&
-          fetchQuery(ctx.relay, route.query, variables).toPromise(),
+        route.component?.().then((x) => x.default),
+        query && fetchQuery(ctx.relay, query, variables).toPromise(),
       ]);
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/web/main.tsx
+++ b/web/main.tsx
@@ -9,5 +9,15 @@ import * as ReactDOM from "react-dom";
 import history from "history/browser";
 
 import { App } from "./common";
+import { createRelay } from "./core/relay";
 
-ReactDOM.render(<App history={history} />, document.getElementById("root"));
+// Dehydrate the initial API response and initialize a Relay store
+const data = document.getElementById("data")?.innerHTML.trim();
+const records = data ? JSON.parse(data) : undefined;
+const relay = createRelay({ records });
+
+// Render the top-level React component
+ReactDOM.render(
+  <App history={history} relay={relay} />,
+  document.getElementById("root"),
+);

--- a/web/proxy/index.ts
+++ b/web/proxy/index.ts
@@ -79,7 +79,8 @@ async function handleEvent(event: FetchEvent) {
   }
 
   // Inject page metadata such as <title>, <meta name="description" contents="..." />, etc.
-  const res = transform(route, await resPromise);
+  // and serialized API response <script id="data" type="application/json">...</script>
+  const res = transform(await resPromise, route, relay);
   return new Response(res.body, {
     status: route.error?.status || 200,
     headers: res.headers,

--- a/web/proxy/transform.ts
+++ b/web/proxy/transform.ts
@@ -4,9 +4,14 @@
  * @copyright 2016-present Kriasoft (https://git.io/vMINh)
  */
 
+import type { Environment } from "relay-runtime";
 import type { RouteResponse } from "../core/router";
 
-export function transform(route: RouteResponse, res: Response): Response {
+export function transform(
+  res: Response,
+  route: RouteResponse,
+  relay: Environment,
+): Response {
   return new HTMLRewriter()
     .on("title:first-of-type", {
       // <title>...</title>
@@ -22,6 +27,13 @@ export function transform(route: RouteResponse, res: Response): Response {
         if (route.description) {
           el.setAttribute("content", route.description);
         }
+      },
+    })
+    .on("script#data", {
+      element(el) {
+        el.setInnerContent(
+          JSON.stringify(relay.getStore().getSource().toJSON()),
+        );
       },
     })
     .transform(res);

--- a/web/public/index.html
+++ b/web/public/index.html
@@ -21,12 +21,19 @@
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
     <!--
-      This HTML file is a template.
-      If you open it directly in the browser, you will see an empty page.
-      You can add webfonts, meta tags, or analytics to this file.
-      The build step will place the bundled scripts into the <body> tag.
-      To begin the development, run `npm start` or `yarn start`.
-      To create a production bundle, use `npm run build` or `yarn build`.
+      Below is the placeholder for a serialized Relay store that is intended
+      to be injected by the Cloudflare Worker script. See `proxy/transform.ts`.
+
+      <script id="data" type="application/json">
+        {
+          "client:root": {
+            "__id": "client:root",
+            "__typename": "__Root",
+            "me": null
+          }
+        }
+      </script>
     -->
+    <script id="data" type="application/json"></script>
   </body>
 </html>


### PR DESCRIPTION
When an HTML page is being served from CDN edge locations via Cloudflare Workers (see `proxy/index.ts`, `proxy/transform.ts`), it injects the serialized API response (Relay store) such as:

```html
<script id="data" type="application/json">
  {
    "client:root": {
      "__id": "client:root",
      "__typename": "__Root",
      "me": { id: "123", name: "John", email: "john@example.com" }
    }
  }
</script>
```

Once the app is being bootstrapped on the client-side (in the browser), this data is being deserialized and passed into the Relay client.

```tsx
// Dehydrate the initial API response and initialize a Relay store
const data = document.getElementById("data")?.innerHTML.trim();
const records = data ? JSON.parse(data) : undefined;
const relay = createRelay({ records });

// Render the top-level React component
ReactDOM.render(
  <App history={history} relay={relay} />,
  document.getElementById("root"),
);
```