### PR TITLE
Prefer singular database table names

### DIFF
--- a/api/context.ts
+++ b/api/context.ts
@@ -57,7 +57,7 @@ export class Context {
 
   userById = new DataLoader<string, User | null>((keys) =>
     db
-      .table<User>("users")
+      .table<User>("user")
       .whereIn("id", keys)
       .select()
       .then((rows) =>
@@ -71,7 +71,7 @@ export class Context {
 
   userByUsername = new DataLoader<string, User | null>((keys) =>
     db
-      .table<User>("users")
+      .table<User>("user")
       .whereIn("username", keys)
       .select()
       .then((rows) =>
@@ -85,7 +85,7 @@ export class Context {
 
   identitiesByUserId = new DataLoader<string, Identity[]>((keys) =>
     db
-      .table<Identity>("identities")
+      .table<Identity>("identity")
       .whereIn("user_id", keys)
       .select()
       .then((rows) => mapToMany(rows, keys, (x) => x.user_id)),

--- a/api/mutations/auth.ts
+++ b/api/mutations/auth.ts
@@ -40,7 +40,7 @@ export const signIn: GraphQLFieldConfig<unknown, Context, any> = {
     //   Authenticate user with the provided Firebase ID token,
     //   or username / email and password.
 
-    const user = await db.table<User>("users").where({ id: "wp60xu" }).first();
+    const user = await db.table<User>("user").where({ id: "wp60xu" }).first();
     const me = await ctx.signIn(user);
 
     return { me };

--- a/api/mutations/user.ts
+++ b/api/mutations/user.ts
@@ -52,7 +52,7 @@ export const updateUser = mutationWithClientMutationId({
       input.username === undefined
         ? true
         : await db
-            .table("users")
+            .table("user")
             .where({ username: input.username?.trim() || null })
             .whereNot({ id })
             .select(db.raw("1"))
@@ -103,7 +103,7 @@ export const updateUser = mutationWithClientMutationId({
 
     if (Object.keys(data).length) {
       [user] = await db
-        .table<User>("users")
+        .table<User>("user")
         .where({ id })
         .update({ ...data, updated_at: db.fn.now() })
         .returning("*");

--- a/api/queries/user.ts
+++ b/api/queries/user.ts
@@ -51,7 +51,7 @@ export const users: GraphQLFieldConfig<unknown, Context> = {
     // Only admins are allowed to fetch the list of users
     ctx.ensureAuthorized((user) => user.admin);
 
-    const query = db.table<User>("users");
+    const query = db.table<User>("user");
 
     const limit = args.first === undefined ? 50 : args.first;
     const offset = args.after ? cursorToOffset(args.after) + 1 : 0;

--- a/api/session.ts
+++ b/api/session.ts
@@ -23,7 +23,7 @@ async function getUser(req: Request): Promise<User | null> {
         issuer: env.APP_ORIGIN,
         audience: env.APP_NAME,
       }) as { sub: string };
-      const user = await db.table("users").where({ id: token.sub }).first();
+      const user = await db.table("user").where({ id: token.sub }).first();
       return user || null;
     } catch (err) {
       console.error(err);
@@ -42,7 +42,7 @@ async function signIn(
   }
 
   [user] = await db
-    .table<User>("users")
+    .table<User>("user")
     .where({ id: user.id })
     .update({ last_login: db.fn.now() })
     .returning("*");

--- a/api/utils/id.ts
+++ b/api/utils/id.ts
@@ -38,4 +38,4 @@ function createNewId(table: string, size: number) {
   };
 }
 
-export const newUserId = createNewId("users", 6);
+export const newUserId = createNewId("user", 6);

--- a/api/utils/username.ts
+++ b/api/utils/username.ts
@@ -36,7 +36,7 @@ export async function generateUsername(email?: string): Promise<string> {
   // Verify that the username is unique
   const {
     rows: [{ exists }],
-  } = await db.raw("SELECT EXISTS (SELECT * FROM users WHERE username = ?)", [
+  } = await db.raw(`SELECT EXISTS (SELECT * FROM "user" WHERE username = ?)`, [
     username,
   ]);
 

--- a/db/migrations/001_initial.js
+++ b/db/migrations/001_initial.js
@@ -33,7 +33,7 @@ module.exports.up = async (/** @type {Knex} */ db) /* prettier-ignore */ => {
   // Custom types
   await db.raw(`CREATE TYPE identity_provider AS ENUM (${idps.map(x => `'${x}'`).join(', ')})`);
 
-  await db.schema.createTable("users", (table) => {
+  await db.schema.createTable("user", (table) => {
     table.specificType("id", "user_id").notNullable().primary();
     table.string("username", 50).notNullable().unique();
     table.string("email", 100);
@@ -51,10 +51,10 @@ module.exports.up = async (/** @type {Knex} */ db) /* prettier-ignore */ => {
     table.timestamp("last_login");
   });
 
-  await db.schema.createTable("identities", (table) => {
+  await db.schema.createTable("identity", (table) => {
     table.specificType("provider", "identity_provider").notNullable();
     table.string("id", 36).notNullable();
-    table.specificType("user_id", "user_id").notNullable().references("id").inTable("users").onDelete("CASCADE").onUpdate("CASCADE");
+    table.specificType("user_id", "user_id").notNullable().references("id").inTable("user").onDelete("CASCADE").onUpdate("CASCADE");
     table.text("username");
     table.text("email");
     table.boolean("email_verified");
@@ -75,8 +75,8 @@ module.exports.up = async (/** @type {Knex} */ db) /* prettier-ignore */ => {
 };
 
 module.exports.down = async (/** @type {Knex} */ db) => {
-  await db.schema.dropTableIfExists("identities");
-  await db.schema.dropTableIfExists("users");
+  await db.schema.dropTableIfExists("identity");
+  await db.schema.dropTableIfExists("user");
   await db.raw("DROP TYPE IF EXISTS identity_provider");
   await db.raw("DROP DOMAIN IF EXISTS user_id");
 };

--- a/db/scripts/repl.js
+++ b/db/scripts/repl.js
@@ -35,7 +35,7 @@ Promise.resolve()
     console.log(x.version);
     console.log(`Connected to "${x.database}". Usage example:`);
     console.log(``);
-    console.log(`   await db.table("users").first()`);
+    console.log(`   await db.table("user").first()`);
     console.log(`   await db.raw("select version()")`);
     console.log(``);
     console.log(`Type ".exit" to exit the REPL`);

--- a/db/scripts/update-types.js
+++ b/db/scripts/update-types.js
@@ -9,16 +9,6 @@ const path = require("path");
 const knex = require("knex");
 const { camelCase, upperFirst } = require("lodash");
 
-function singular(word) {
-  return word.endsWith("ies")
-    ? `${word.substring(0, word.length - 3)}y`
-    : word.endsWith("es")
-    ? `${word.substring(0, word.length - 1)}`
-    : word.endsWith("s")
-    ? word.substring(0, word.length - 1)
-    : word;
-}
-
 async function updateTypes() {
   const db = knex(require("../knexfile"));
   const lines = [];
@@ -66,9 +56,7 @@ async function updateTypes() {
     // Construct TypeScript db record types
     columns.forEach((x, i) => {
       if (!(columns[i - 1] && columns[i - 1].table === x.table)) {
-        lines.push(
-          `export type ${singular(upperFirst(camelCase(x.table)))} = {`,
-        );
+        lines.push(`export type ${upperFirst(camelCase(x.table))} = {`);
       }
 
       const nullable = x.null === "YES" ? " | null" : "";

--- a/db/seeds/00_reset.js
+++ b/db/seeds/00_reset.js
@@ -6,5 +6,5 @@
  */
 
 module.exports.seed = async (/** @type {Knex} */ db) => {
-  await db.table("users").delete();
+  await db.table("user").delete();
 };

--- a/db/seeds/01_users.js
+++ b/db/seeds/01_users.js
@@ -69,5 +69,5 @@ module.exports.seed = async (/** @type {Knex} */ db) => {
 
   fs.writeFileSync(jsonFile, stringify(users), "utf8");
 
-  await db.table("users").insert(users);
+  await db.table("user").insert(users);
 };


### PR DESCRIPTION
Update sample database schema and `update-types` script to use singular names for database tables.

- `users` -> `user`
- `identities` -> `identity`

It's a bit more practical. You can run `yarn db:reset` to migrate the actual db schema after pulling this update.